### PR TITLE
Set ListItem type to video

### DIFF
--- a/default.py
+++ b/default.py
@@ -50,6 +50,7 @@ if mode is '':
         _listitem = '%s - %s' %(item[i], loc[i]) if loc[i] != '' else item[i]
         li = xbmcgui.ListItem(_listitem, iconImage =icon)
         li.setProperty('isPlayable', 'true')
+        li.setInfo('video', {'tag': 'Documentary'})
 
         if cam[i] != '':
             xbmcplugin.addDirectoryItem(_addonHandle, cam[i], li)


### PR DESCRIPTION
if camera URL doesn't have extension then the following warning occurs in kodi.log:
"WARNING: Playlist Player: ListItem type must be audio or video, use ListItem::setInfo to specify!"
and no playback occurs. 
This change set info with some dummy value.